### PR TITLE
Experiment: fix link errors by providing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ before_script:
   - (mdbook -V | grep -qi "^mdbook\s*v0\.2" || cargo install mdbook --version "^0.2" --force)
 script:
 - mdbook build
-# we don't test, since there are unsolvable linker errors:
-# https://github.com/rust-lang-nursery/mdBook/issues/706
+- (git clone https://github.com/rust-random/rand.git && cd rand && cargo build && cd .. && mdbook test -L rand/target/debug/deps)
 
 deploy:
   provider: pages


### PR DESCRIPTION
Unfortunately this fails locally because my system has multiple versions of
rand installed. Since the CI systems probably don't, it might work there.