### PR TITLE
Point dead link to the Wayback Machine

### DIFF
--- a/src/guide-rngs.md
+++ b/src/guide-rngs.md
@@ -287,7 +287,8 @@ approachable and explains more concepts.
 
 Another good paper about RNG quality is
 ["Good random number generators are (not so) easy to find"](
-http://random.mat.sbg.ac.at/results/peter/A19final.pdf) by P. Hellekalek.
+https://web.archive.org/web/20160801142711/http://random.mat.sbg.ac.at/results/peter/A19final.pdf)
+by P. Hellekalek.
 
 
 [`rngs` module]: ../rand/rand/rngs/index.html


### PR DESCRIPTION
The book has a link that is currently broken. This fixes the link by pointing it to the Wayback Machine instead.