### PR TITLE
Document rationale for returning float types for a discrete distribution (Poisson)

### DIFF
--- a/src/guide-dist.md
+++ b/src/guide-dist.md
@@ -114,6 +114,11 @@ much faster than sampling `n` trials individually.
 
 The [`Poisson`] distribution expresses the expected number of events
 occurring within a fixed interval, given that events occur with fixed rate λ.
+[`Poisson`] distribution sampling generates `Float` values because `Float`s
+are used in the sampling calculations, and we prefer to defer to the user on
+integer types and the potentially lossy and panicking associated conversions.
+For example, in Rust >= 1.45, `u64` values can be attained with
+`rng.sample(Poisson) as u64`.
 
 ### Weighted sequences
 

--- a/src/guide-dist.md
+++ b/src/guide-dist.md
@@ -117,8 +117,10 @@ occurring within a fixed interval, given that events occur with fixed rate λ.
 [`Poisson`] distribution sampling generates `Float` values because `Float`s
 are used in the sampling calculations, and we prefer to defer to the user on
 integer types and the potentially lossy and panicking associated conversions.
-For example, in Rust >= 1.45, `u64` values can be attained with
-`rng.sample(Poisson) as u64`.
+For example, `u64` values can be attained with `rng.sample(Poisson) as u64`.
+
+Note that out of range float to int conversions with `as` result in undefined
+behavior for Rust <1.45 and a saturating conversion for Rust >=1.45.
 
 ### Weighted sequences
 


### PR DESCRIPTION
This PR expands the Poisson documentation:  
* Provide rationale for the Float return type
* Notes concerns around lossy and panicking integer conversions
* Provides an example conversion to u64

https://github.com/rust-random/rand/issues/1093