### PR TITLE
Fix Rng::gen_range explanation and example

### DIFF
--- a/src/guide-values.md
+++ b/src/guide-values.md
@@ -21,8 +21,7 @@ convenience functions for producing uniformly distributed values:
     
     This method is a convenience wrapper around the [`Standard`] distribution,
     as documented in the [next section](guide-dist.html#uniform-distributions).
--   [`Rng::gen_range`] generates an unbiased random value with given bounds
-    `low` (inclusive) and `high` (exclusive)
+-   [`Rng::gen_range`] generates an unbiased random value in the given range
 -   [`Rng::fill`] and [`Rng::try_fill`] are optimised functions for filling any byte or
     integer slice with random values
 
@@ -50,7 +49,7 @@ let i: i32 = rng.gen();
 let x: f64 = rng.gen();
 
 // simulate rolling a die:
-let roll = rng.gen_range(1, 7);
+let roll = rng.gen_range(1..7);
 ```
 
 Additionally, the [`random`] function is a short-cut to [`Rng::gen`] on the [`thread_rng`]:

--- a/src/overview.md
+++ b/src/overview.md
@@ -29,7 +29,7 @@ The [`Rng`] trait provides a layer of convenience on top of [`RngCore`], whose
 highlights are:
 
 -   [`Rng::gen()`] provides a random value of any type supporting the [`Standard`] distribution.
--   [`Rng::gen_range(low, high)`] provides a uniform random value within the given range.
+-   [`Rng::gen_range(low..high)`] provides a uniform random value within the given range.
 -   [`Rng::gen_bool(p)`] yields `true` with probability `p`.
 -   [`Rng::sample(distribution)`] produces a value from the supplied `distribution`.
 -   [`Rng::fill(dest)`] fills any "byte slice" with random data.
@@ -48,7 +48,7 @@ random values. Key contents:
     different types, from ints to floats to tuples, arrays and `Option`).
 -   [`Open01`] and [`OpenClosed01`] provide variations on sampling floating point
     values from the 0-1 range.
--   [`Uniform`] is the backbone behind [`Rng::gen_range(low, high)`], allowing uniform sampling
+-   [`Uniform`] is the backbone behind [`Rng::gen_range(low..high)`], allowing uniform sampling
     from a configured type-specific range.
 
 Many more distributions are available; consult the API documentation.
@@ -63,7 +63,7 @@ The [`seq`] module allows:
 
 [`prelude`]: ../rand/rand/prelude/index.html
 [`distributions`]: ../rand/rand/distributions/index.html
-[`Rng::gen_range(low, high)`]: ../rand/rand/trait.Rng.html#method.gen_range
+[`Rng::gen_range(low..high)`]: ../rand/rand/trait.Rng.html#method.gen_range
 [`random()`]: ../rand/rand/fn.random.html
 [`Rng::fill(dest)`]: ../rand/rand/trait.Rng.html#method.fill
 [`Rng::gen_bool(p)`]: ../rand/rand/trait.Rng.html#method.gen_bool

--- a/src/overview.md
+++ b/src/overview.md
@@ -29,7 +29,12 @@ The [`Rng`] trait provides a layer of convenience on top of [`RngCore`], whose
 highlights are:
 
 -   [`Rng::gen()`] provides a random value of any type supporting the [`Standard`] distribution.
--   [`Rng::gen_range(low..high)`] provides a uniform random value within the given range.
+-   [`Rng::gen_range(low..high)`] provides a uniform random value within the
+    given range. A range includes the lower bound `low` and excludes the upper
+    bound `high`.
+-   [`Rng::gen_range(low..=high)`] provides a uniform random value within the
+    given inclusive range. Here the range is inclusive of both the lower bound
+    `low` and the upper bound `high`.
 -   [`Rng::gen_bool(p)`] yields `true` with probability `p`.
 -   [`Rng::sample(distribution)`] produces a value from the supplied `distribution`.
 -   [`Rng::fill(dest)`] fills any "byte slice" with random data.
@@ -64,6 +69,7 @@ The [`seq`] module allows:
 [`prelude`]: ../rand/rand/prelude/index.html
 [`distributions`]: ../rand/rand/distributions/index.html
 [`Rng::gen_range(low..high)`]: ../rand/rand/trait.Rng.html#method.gen_range
+[`Rng::gen_range(low..=high)`]: ../rand/rand/trait.Rng.html#method.gen_range
 [`random()`]: ../rand/rand/fn.random.html
 [`Rng::fill(dest)`]: ../rand/rand/trait.Rng.html#method.fill
 [`Rng::gen_bool(p)`]: ../rand/rand/trait.Rng.html#method.gen_bool


### PR DESCRIPTION
The function now expects a single Range argument