### PR TITLE
Remove recommendation to test deadlinks

### DIFF
--- a/src/contrib-doc.md
+++ b/src/contrib-doc.md
@@ -33,17 +33,10 @@ On Linux, it is easy to set up automatic rebuilds after any edit:
 while inotifywait -r -e close_write src/ rand_*/; do cargo doc; done
 ```
 
-After editing API documentation, we reccomend testing examples and
-checking for broken links:
+After editing API documentation, we reccomend testing examples:
 
 ```sh
 cargo test --doc
-
-cargo install cargo-deadlinks
-# It is recommended to remove left-over files from previous compilations
-rm -rf /target/doc
-cargo doc --all --no-deps
-cargo deadlinks --dir target/doc
 ```
 
 Rand API docs are automatically built and hosted at


### PR DESCRIPTION
I don't think this is particularly useful now since `cargo doc` now reports broken links.

That said, it does still report some stuff, e.g.:
```
Found invalid urls in rngs/struct.OsRng.html:
        Fragment #tymethod.into_bits at rngs/struct.OsRng.html does not exist!
        Fragment #tymethod.vzip at rngs/struct.OsRng.html does not exist!
        Fragment #tymethod.from_cast at rngs/struct.OsRng.html does not exist!
        Fragment #tymethod.from_bits at rngs/struct.OsRng.html does not exist!
        Fragment #tymethod.cast at rngs/struct.OsRng.html does not exist!
```
Well, [`ppv_lite86::VZip`](https://docs.rs/ppv-lite86/0.2.10/ppv_lite86/trait.VZip.html) has a blanket implementation, as does [`packed_simd_2::FromCast`](https://docs.rs/packed_simd_2/0.3.5/packed_simd_2/trait.FromCast.html), etc... but the fact that these show up in the docs at all (regardless of the broken links) is just an (unwanted) side-effect of the docs build process. One that [does affect docs.rs](https://docs.rs/rand/0.8.4/rand/rngs/struct.OsRng.html) but hardly worth mentioning.

A skim through the (many) similar reports does not show anything more interesting.