### PR TITLE
Document how to implement uniform sampling for enums

### DIFF
--- a/src/contrib-doc.md
+++ b/src/contrib-doc.md
@@ -33,7 +33,7 @@ On Linux, it is easy to set up automatic rebuilds after any edit:
 while inotifywait -r -e close_write src/ rand_*/; do cargo doc; done
 ```
 
-After editing API documentation, we reccomend testing examples and
+After editing API documentation, we recommend testing examples and
 checking for broken links:
 
 ```sh
@@ -91,7 +91,7 @@ Examples:
 https://docs.rs/getrandom/0.1/getrandom/fn.getrandom.html
 ```
 
-## Auxilliary documentation
+## Auxiliary documentation
 
 ### README files
 

--- a/src/contrib-scope.md
+++ b/src/contrib-scope.md
@@ -5,7 +5,7 @@ monolithic crate to using a "main" crate plus multiple single-purpose crates.
 For new functionality, one must consider where, and whether, it fits within the
 Rand project.
 
-Small, focussed crates may be used for a few reasons, but we aim *not* to
+Small, focused crates may be used for a few reasons, but we aim *not* to
 maximally divide functionality into small crates. Valid reasons for using a
 separate crate for a feature are therefore:
 
@@ -45,7 +45,7 @@ implementation effort. See
 [getrandom#4](https://github.com/rust-random/getrandom/issues/4).
 
 The `rand_jitter` crate provides an implementation of a
-[CPU Jitter](http://www.chronox.de/jent.html) entropy harvestor, and is only
+[CPU Jitter](http://www.chronox.de/jent.html) entropy harvester, and is only
 included in Rand for historical reasons.
 
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -13,13 +13,13 @@ thus we may take considerable time to get back to you.
     scope of the project or is an enhancement. Note that whether something is
     considered a *defect* may depend on your point of view. We may choose to
     reject contributions to avoid increasing our workload.
-    
+
     If you wish to expand the scope of the project (e.g. new platforms or
     additional CI testing) then please be prepared to provide on-going
     support.
 -   **Fixes:** if you can easily fix this yourself, please consider making a PR
     instead of opening an issue. On the other hand if it's less easy or looks
-    like it may conflict with other work, don't hesistate to open an issue.
+    like it may conflict with other work, don't hesitate to open an issue.
 
 ## Pull Requests
 

--- a/src/crates-gen.md
+++ b/src/crates-gen.md
@@ -7,17 +7,17 @@ random-number sources, and is an important building block of `rand` and
 `rand_core` as well as a number of cryptography libraries.
 It is not intended for usage outside of low-level libraries.
 
-In some cases, particularly when targetting WASM, end-users may need to
+In some cases, particularly when targeting WASM, end-users may need to
 configure this crate.
 Consult the [`getrandom`] documentation for the relevant version.
 
 ## CPU Jitter
 
-The [`rand_jitter`] crate implements a CPU-jitter-based entropy harvestor which
+The [`rand_jitter`] crate implements a CPU-jitter-based entropy harvester which
 may be used to provide an alternative source of entropy where a high-resolution
 CPU timer is available.
 
-It should be noted that CPU-jitter harvestors [may be prone to side-channel
+It should be noted that CPU-jitter harvesters [may be prone to side-channel
 attacks](https://github.com/rust-random/rand/issues/699) and that this
 implementation is quite slow (due to conservative estimates of entropy gained
 per step).

--- a/src/guide-dist.md
+++ b/src/guide-dist.md
@@ -78,6 +78,27 @@ Lets go over the distributions by type:
     [`Uniform`] (for the latter, `low` and `high` parameters are *also* SIMD
     types, effectively sampling from multiple ranges simultaneously). SIMD
     support is gated behind a [feature flag](../features.html#simd-support).
+-   For enums, you have to implement uniform sampling yourself. For example, you
+    could use the following approach:
+    ```rust
+    pub enum Food {
+        Burger,
+        Pizza,
+        Kebab,
+    }
+
+    impl Distribution<Food> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Food {
+            let index: u8 = rng.gen_range(0..3);
+            match index {
+                0 => Food::Burger,
+                1 => Food::Pizza,
+                2 => Food::Kebab,
+                _ => unreachable!(),
+            }
+        }
+    }
+    ```
 
 # Non-uniform distributions
 

--- a/src/guide-dist.md
+++ b/src/guide-dist.md
@@ -28,7 +28,7 @@ The most obvious type of distribution is the one we already discussed: one
 without pattern, where each value or range of values is equally likely. This is
 known as *uniform*.
 
-Rand actually has several variants of this, repesenting different ranges:
+Rand actually has several variants of this, representing different ranges:
 
 -   [`Standard`] requires no parameters and samples values uniformly according
     to the type. [`Rng::gen`] provides a short-cut to this distribution.

--- a/src/guide-gen.md
+++ b/src/guide-gen.md
@@ -43,7 +43,7 @@ number generators are deterministic and can be defined by just:
 The fact that these are deterministic can sometimes be very useful: it allows a
 simulation, randomised art work or game to be repeated exactly, producing a
 result which is a function of the seed. For more on this see the
-[portability](portability.md) chapter (note that determinicity alone isn't
+[portability](portability.md) chapter (note that determinism alone isn't
 enough to guarantee reproducibility).
 
 The other big attraction of PRNGs is their speed: some of these algorithms

--- a/src/portability.md
+++ b/src/portability.md
@@ -53,7 +53,7 @@ it does matter.
 A simple rule follows: if portability is required, *never* sample a `usize` or
 `isize` value directly.
 
-Within Rand we adhere to this rule whenever possible. All sequence-releated
+Within Rand we adhere to this rule whenever possible. All sequence-related
 code requiring a bounded `usize` value will sample a `u32` value unless the
 upper bound exceeds `u32::MAX`.
 (Note that this actually improves benchmark performance in many cases.)

--- a/src/update-0.8.md
+++ b/src/update-0.8.md
@@ -162,7 +162,7 @@ In `rand_distr` v0.4, more changes occurred (since v0.2):
     have to be migrated. Thanks to the math functions from `num_traits::Float`,
     `rand_distr` now supports `no_std`.
 
-Additonally, there were some minor improvements:
+Additionally, there were some minor improvements:
 
 -   The treatment of rounding errors and NaN was improved for the
     [`WeightedIndex`] distribution.


### PR DESCRIPTION
This fixes https://github.com/rust-random/rand/issues/644.

Also fixes some typos.