### PR TITLE
Fix typo 'aleviate' -> 'alleviate'

### DIFF
--- a/src/crate-reprod.md
+++ b/src/crate-reprod.md
@@ -65,4 +65,4 @@ The results of floating point arithmetic depend on rounding modes and
 implementation details. In particular, the results of transcendental functions vary
 from platform to platform. Due to this, results of distributions in `rand_distr` using `f32` or `f64` may not be portable.
 
-To aleviate (or further complicate) this concern, we prefer to use `libm` over `std` implementations of these transcendental functions. See [rand_distr features](crate-features.html#rand_distr-features).
+To alleviate (or further complicate) this concern, we prefer to use `libm` over `std` implementations of these transcendental functions. See [rand_distr features](crate-features.html#rand_distr-features).


### PR DESCRIPTION
Fix a typo. Literally just a one letter change.