### PR TITLE
add a section describing renamed methods and functions

### DIFF
--- a/src/update-0.9.md
+++ b/src/update-0.9.md
@@ -9,6 +9,20 @@ The following is a migration guide focussing on potentially-breaking changes. Fo
 -   [rand_core/CHANGELOG.md](https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md).
 -   [rand_distr/CHANGELOG.md](https://github.com/rust-random/rand/blob/master/rand_distr/CHANGELOG.md).
 
+## Renamed functions and methods
+
+In the 2024 edition, [`gen` is a reserved keyword][gen-keyword]. The raw syntax `r#gen()` is awkward, so some methods in `rand::Rng` have been renamed:
+- `gen` -> `random`
+- `gen_range` -> `random_range`
+- `gen_bool` -> `random_bool`
+- `gen_ratio` -> `random_ratio`
+
+Additionally, `rand::thread_rng()` has been renamed to the simpler `rng()`.
+
+The previous names still exist but are deprecated.
+
+[gen-keyword]: https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html
+
 ## Security
 
 It was determined in [#1514](https://github.com/rust-random/rand/pull/1514) that


### PR DESCRIPTION
Add a section describing methods that were renamed, specifically those driven by the `gen` keyword in the 2024 edition.

I put it right at the top, because I expect these methods are very widely used. I'm happy to move it to another location though-- just tell me where.

Resolves #75.