### PR TITLE
Remove 'mdbook test' command from README and include workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-book
-tests/src/*
-tests/target/*
+/book
+/tests/src/*
+/tests/target
 Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 book
 tests/src/*
+tests/target/*
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo install mdbook --version "^0.4" --force
 mdbook build --open
 ```
 
-`mdbook test` does not currently work, see: https://github.com/rust-lang/mdBook/issues/394
+`mdbook test` does not currently work, see: https://github.com/rust-random/book/issues/79
 
 As a workaround, please run:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ To preview your changes locally:
 ```
 cargo install mdbook --version "^0.4" --force
 mdbook build --open
-mdbook test
+```
+
+`mdbook test` does not currently work, see: https://github.com/rust-lang/mdBook/issues/394
+
+As a workaround, please run:
+
+```
+cd tests
+./generate.sh
+cargo test
 ```
 
 ## License


### PR DESCRIPTION
In reference to https://github.com/rust-random/book/issues/79

I also updated the .gitignore so that artifacts generated by testing won't get accidentally uploaded