### PR TITLE
Fix gh-pages deployment source

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,4 +20,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
+          publish_dir: ./book/html


### PR DESCRIPTION
Fixes deployment from #81. The addition of `[output.linkcheck]` in `book.toml` changes mdbook's output.