### PR TITLE
remove-feature-small_rng

### DIFF
--- a/src/guide-start.md
+++ b/src/guide-start.md
@@ -6,7 +6,7 @@ Next, lets make a new crate and add rand as a dependency:
 ```sh
 cargo new randomly
 cd randomly
-cargo add rand --features small_rng
+cargo add rand 
 ```
 
 Now, paste the following into `src/main.rs`:


### PR DESCRIPTION
`cargo add rand --features small_rng` no longer works since the removal of the `small_rng` feature flag. This PR makes a small change of making it just `cargo add rand` :)