### PR TITLE
Clean up RNG comparison table

### DIFF
--- a/src/guide-rngs.md
+++ b/src/guide-rngs.md
@@ -40,9 +40,9 @@ You may wish to refer to the [pcg-random] and [xoshiro] websites.
 | name | full name | performance | memory | quality | period | features |
 |------|-----------|-------------|--------|---------|--------|----------|
 | [`SmallRng`] | (unspecified) | (unspecified) | (unspecified) | ★★★☆☆ | ≥ `u32` * 2<sup>64</sup> | not portable |
-| [`Pcg32`] | PCG XSH RR 64/32 (LCG) | 5 GB/s | 16 bytes | ★★★☆☆ | `u32` * 2<sup>64</sup> | — |
-| [`Pcg64`] | PCG XSL 128/64 (LCG) | 7 GB/s | 32 bytes | ★★★☆☆ | `u64` * 2<sup>128</sup> | — |
-| [`Pcg64Mcg`] | PCG XSL 128/64 (MCG) | 8 GB/s | 16 bytes | ★★★☆☆ | `u64` * 2<sup>126</sup> | — |
+| [`Pcg32`] | PCG XSH RR 64/32 (LCG) | 5 GB/s | 16 bytes | ★★★☆☆ | `u32` * 2<sup>64</sup> | jump-ahead |
+| [`Pcg64`] | PCG XSL 128/64 (LCG) | 7 GB/s | 32 bytes | ★★★☆☆ | `u64` * 2<sup>128</sup> | jump-ahead |
+| [`Pcg64Mcg`] | PCG XSL 128/64 (MCG) | 8 GB/s | 16 bytes | ★★★☆☆ | `u64` * 2<sup>126</sup> | jump-ahead |
 | [`XorShiftRng`] | Xorshift 32/128 | 7 GB/s | 16 bytes | ★☆☆☆☆ | `u32` * 2<sup>128</sup> - 1 | — |
 | [`Xoshiro256PlusPlus`] | Xoshiro256++ | 11 GB/s | 32 bytes | ★★★☆☆ | `u64` * 2<sup>256</sup> - 1 | jump-ahead |
 | [`Xoshiro256Plus`] | Xoshiro256+ | 13 GB/s | 32 bytes | ★★☆☆☆ | `u64` * 2<sup>256</sup> - 1 | jump-ahead |

--- a/src/guide-rngs.md
+++ b/src/guide-rngs.md
@@ -39,7 +39,7 @@ You may wish to refer to the [pcg-random] and [xoshiro] websites.
 
 | name | full name | performance | memory | quality | period | features |
 |------|-----------|-------------|--------|---------|--------|----------|
-| [`SmallRng`] | (unspecified) | 11 GB/s | 16 bytes | ★★★☆☆ | ≥ `u32` * 2<sup>64</sup> | not portable |
+| [`SmallRng`] | (unspecified) | (unspecified) | (unspecified) | ★★★☆☆ | ≥ `u32` * 2<sup>64</sup> | not portable |
 | [`Pcg32`] | PCG XSH RR 64/32 (LCG) | 5 GB/s | 16 bytes | ★★★☆☆ | `u32` * 2<sup>64</sup> | — |
 | [`Pcg64`] | PCG XSL 128/64 (LCG) | 7 GB/s | 32 bytes | ★★★☆☆ | `u64` * 2<sup>128</sup> | — |
 | [`Pcg64Mcg`] | PCG XSL 128/64 (MCG) | 8 GB/s | 16 bytes | ★★★☆☆ | `u64` * 2<sup>126</sup> | — |
@@ -79,9 +79,10 @@ table since CSPRNGs may not have observable defects.
 
 | name | full name |  performance | initialization | memory | security (predictability) | forward secrecy |
 |------|-----------|--------------|--------------|----------|----------------|-------------------------|
-| [`StdRng`] | (unspecified) | 4.1 GB/s | fast | 136 bytes | widely trusted | no |
+| [`StdRng`] | (unspecified) | (unspecified) | fast | (unspecified) | widely trusted | no |
 | [`ChaCha20Rng`] | ChaCha20 | 2.6 GB/s | fast | 136 bytes | [rigorously analysed](https://tools.ietf.org/html/rfc7539#section-1) | no |
-| [`ChaCha8Rng`] | ChaCha8 | 5.8 GB/s | fast | 136 bytes | small security margin | no |
+| [`ChaCha12Rng`] | ChaCha12 | 4.1 GB/s | fast | 136 bytes | [large security margin](https://eprint.iacr.org/2019/1492) | no |
+| [`ChaCha8Rng`] | ChaCha8 | 5.8 GB/s | fast | 136 bytes | [sufficient security margin](https://eprint.iacr.org/2019/1492) | no |
 | [`Hc128Rng`] | HC-128 | 4.6 GB/s | slow | 4176 bytes | [recommended by eSTREAM](http://www.ecrypt.eu.org/stream/) | no |
 | [`IsaacRng`] | ISAAC | 2.1 GB/s | slow | 2072 bytes | [unknown](https://burtleburtle.net/bob/rand/isaacafa.html) | unknown |
 | [`Isaac64Rng`] | ISAAC-64 | 3.7 GB/s | slow | 4136 bytes| unknown | unknown |
@@ -322,6 +323,7 @@ by P. Hellekalek.
 [`Xoshiro256Plus`]: https://docs.rs/rand_xoshiro/latest/rand_xoshiro/struct.Xoshiro256Plus.html
 [`SplitMix64`]: https://docs.rs/rand_xoshiro/latest/rand_xoshiro/struct.SplitMix64.html
 [`ChaCha20Rng`]: https://docs.rs/chacha20/latest/chacha20/struct.ChaCha20Rng.html
+[`ChaCha12Rng`]: https://docs.rs/chacha20/latest/chacha20/struct.ChaCha12Rng.html
 [`ChaCha8Rng`]: https://docs.rs/chacha20/latest/chacha20/struct.ChaCha8Rng.html
 [`Hc128Rng`]: https://docs.rs/rand_hc/latest/rand_hc/struct.Hc128Rng.html
 [`IsaacRng`]: https://docs.rs/rand_isaac/latest/rand_isaac/isaac/struct.IsaacRng.html

--- a/src/guide-rngs.md
+++ b/src/guide-rngs.md
@@ -39,7 +39,7 @@ You may wish to refer to the [pcg-random] and [xoshiro] websites.
 
 | name | full name | performance | memory | quality | period | features |
 |------|-----------|-------------|--------|---------|--------|----------|
-| [`SmallRng`] | (unspecified) | (unspecified) | (unspecified) | ★★★☆☆ | ≥ `u32` * 2<sup>64</sup> | not portable |
+| [`SmallRng`] | (unspecified) | fast | small | ★★★☆☆ | ≥ `u32` * 2<sup>64</sup> | not portable |
 | [`Pcg32`] | PCG XSH RR 64/32 (LCG) | 5 GB/s | 16 bytes | ★★★☆☆ | `u32` * 2<sup>64</sup> | jump-ahead |
 | [`Pcg64`] | PCG XSL 128/64 (LCG) | 7 GB/s | 32 bytes | ★★★☆☆ | `u64` * 2<sup>128</sup> | jump-ahead |
 | [`Pcg64Mcg`] | PCG XSL 128/64 (MCG) | 8 GB/s | 16 bytes | ★★★☆☆ | `u64` * 2<sup>126</sup> | jump-ahead |
@@ -79,10 +79,10 @@ table since CSPRNGs may not have observable defects.
 
 | name | full name |  performance | initialization | memory | security (predictability) | forward secrecy |
 |------|-----------|--------------|--------------|----------|----------------|-------------------------|
-| [`StdRng`] | (unspecified) | (unspecified) | fast | (unspecified) | widely trusted | no |
-| [`ChaCha20Rng`] | ChaCha20 | 2.6 GB/s | fast | 136 bytes | [rigorously analysed](https://tools.ietf.org/html/rfc7539#section-1) | no |
-| [`ChaCha12Rng`] | ChaCha12 | 4.1 GB/s | fast | 136 bytes | [large security margin](https://eprint.iacr.org/2019/1492) | no |
-| [`ChaCha8Rng`] | ChaCha8 | 5.8 GB/s | fast | 136 bytes | [sufficient security margin](https://eprint.iacr.org/2019/1492) | no |
+| [`StdRng`] | (unspecified) | fast | fast | (unspecified) | widely trusted | no |
+| [`ChaCha20Rng`] | ChaCha20 | 2.6 GB/s | fast | 320 bytes | [rigorously analysed](https://tools.ietf.org/html/rfc7539#section-1) | no |
+| [`ChaCha12Rng`] | ChaCha12 | 4.1 GB/s | fast | 320 bytes | [large security margin](https://eprint.iacr.org/2019/1492) | no |
+| [`ChaCha8Rng`] | ChaCha8 | 5.8 GB/s | fast | 320 bytes | [sufficient security margin](https://eprint.iacr.org/2019/1492) | no |
 | [`Hc128Rng`] | HC-128 | 4.6 GB/s | slow | 4176 bytes | [recommended by eSTREAM](http://www.ecrypt.eu.org/stream/) | no |
 | [`IsaacRng`] | ISAAC | 2.1 GB/s | slow | 2072 bytes | [unknown](https://burtleburtle.net/bob/rand/isaacafa.html) | unknown |
 | [`Isaac64Rng`] | ISAAC-64 | 3.7 GB/s | slow | 4136 bytes| unknown | unknown |

--- a/src/guide-rngs.md
+++ b/src/guide-rngs.md
@@ -80,12 +80,14 @@ table since CSPRNGs may not have observable defects.
 | name | full name |  performance | initialization | memory | security (predictability) | forward secrecy |
 |------|-----------|--------------|--------------|----------|----------------|-------------------------|
 | [`StdRng`] | (unspecified) | fast | fast | (unspecified) | widely trusted | no |
-| [`ChaCha20Rng`] | ChaCha20 | 2.6 GB/s | fast | 320 bytes | [rigorously analysed](https://tools.ietf.org/html/rfc7539#section-1) | no |
-| [`ChaCha12Rng`] | ChaCha12 | 4.1 GB/s | fast | 320 bytes | [large security margin](https://eprint.iacr.org/2019/1492) | no |
-| [`ChaCha8Rng`] | ChaCha8 | 5.8 GB/s | fast | 320 bytes | [sufficient security margin](https://eprint.iacr.org/2019/1492) | no |
+| [`ChaCha20Rng`] | ChaCha20 | 2.6 GB/s | fast | 320 bytes[^size] | [rigorously analysed](https://tools.ietf.org/html/rfc7539#section-1) | no |
+| [`ChaCha12Rng`] | ChaCha12 | 4.1 GB/s | fast | 320 bytes[^size] | [large security margin](https://eprint.iacr.org/2019/1492) | no |
+| [`ChaCha8Rng`] | ChaCha8 | 5.8 GB/s | fast | 320 bytes[^size] | [sufficient security margin](https://eprint.iacr.org/2019/1492) | no |
 | [`Hc128Rng`] | HC-128 | 4.6 GB/s | slow | 4176 bytes | [recommended by eSTREAM](http://www.ecrypt.eu.org/stream/) | no |
 | [`IsaacRng`] | ISAAC | 2.1 GB/s | slow | 2072 bytes | [unknown](https://burtleburtle.net/bob/rand/isaacafa.html) | unknown |
 | [`Isaac64Rng`] | ISAAC-64 | 3.7 GB/s | slow | 4136 bytes| unknown | unknown |
+
+[^size]: The size is an implementation detail, and may change.
 
 It should be noted that the ISAAC generators are only included for
 historical reasons: they have been with the Rust language since the very


### PR DESCRIPTION
What statements we made and didn't make for `StdRng` and `SmallRng` was inconsistent. Now, we only specify what we are willing to guarantee.

The full stats for the currently chosen algorithms are still there: `ChaChaRng12` (newly added to the table) and `Xoshiro256PlusPlus` (unchanged) are part of the comparison.

Also state that `rand_pcg` now supports jump-ahead.